### PR TITLE
View available properties and view single properties

### DIFF
--- a/api/v1/controllers/propertyController.js
+++ b/api/v1/controllers/propertyController.js
@@ -30,6 +30,80 @@ export const addProperty = async (req, res) => {
     }
 };
 
+export const getAllProperty = async (req, res) => {
+    try {
+        const page = parseInt(req.query.page) || 1;
+        const limit = parseInt(req.query.limit) || 10;
+
+        const properties = await prisma.property.findMany({
+            skip: (page - 1) * limit,
+            take: parseInt(limit)
+        });
+
+        if(properties.length == 0) {
+            return res.status(404).json({
+                status: 404,
+                message: "No property has been listed"
+            });
+        }
+
+        return res.status(200).json({
+            status: 200,
+            message: "Property list retrieved Successfully",
+            propertyPerPage: `${properties.length} properties available`,
+            pageNumber: page,
+            limit: limit,
+            data: properties
+        });
+    } catch (error) {
+        return res.status(500).json({
+            status: 500,
+            message: error.message
+        });
+    }
+};
+
+export const getSingleProperty = async (req, res) => {
+    try {
+        const propertyId = req.params.propertyId
+
+        const property = await prisma.property.findUnique({
+            where: {
+                id: propertyId
+            },
+            include: {
+                Rating: {
+                    select: { id: true,
+                        rating: true,
+                        comment: true,
+                        user: {
+                            select: {id: true, firtName: true, lastname: true}
+                        }
+                    }
+                }
+            }
+        });
+
+        if(!property) {
+            return res.status(404).json({
+                status: 404,
+                message: "Property not found"
+            });
+        }
+
+        return res.status(200).json({
+            status: 200,
+            message: "Property retrieved Successfully",
+            data: property
+        });
+    } catch (error) {
+        return res.status(500).json({
+            status: 500,
+            message: error.message
+        });
+    }
+};
+
 export const updateProperty = async (req, res) => {
     const propertyId = req.params.id;
     const { sellerID, location, price, description, squareMeters, propertyType, image } = req.body;

--- a/api/v1/routes/propertyRoutes.js
+++ b/api/v1/routes/propertyRoutes.js
@@ -1,5 +1,5 @@
 import {Router} from "express";
-import { addProperty,updateProperty,deleteProperty} from "../controllers/propertyController.js"
+import { addProperty,updateProperty,deleteProperty, getAllProperty, getSingleProperty} from "../controllers/propertyController.js"
 
 const router = Router();
 
@@ -7,4 +7,7 @@ const router = Router();
 router.post("/", addProperty);
 router.put("/:id", updateProperty);
 router.delete("/:id", deleteProperty);
+router.get('/properties', getAllProperty);
+router.get('/properties/:propertyId', getSingleProperty);
+
 export default router;

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ app.use(express.json());
 
 // API Routes
 app.use('/api/v1/property-hive', ratingRouter);
-app.use("/api/v1/property", propertyRoutes);
+app.use("/api/v1/property-hive", propertyRoutes);
 
 async function main() {
     try {


### PR DESCRIPTION
​## Description
- Added the _getAllProperty_ function to retrieve all available properties, implementing pagination and limit to pages that the users can adjust.
- Handled 404 and 500 errors when there's no property available yet and when there's a server error.

- Added the _getSingleProperty_ function to retrieve a single property with ratings(if available).
- Handled 404 and 500 errors when the property did not exist and when there's a server error.

## Related Issue (Link to linear ticket)
- **View all property**: 
https://linear.app/internpulse/issue/PRO-44/implement-endpoint-for-get-property-list-in-propertyhive

- **View single property**:
https://linear.app/internpulse/issue/PRO-48/implement-backend-endpoint-for-getview-single-property

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.